### PR TITLE
Fix documentation for handle_system_msg

### DIFF
--- a/src/plain_fsm.erl
+++ b/src/plain_fsm.erl
@@ -79,7 +79,7 @@
 %%    receive
 %%       {system, From, Req} ->
 %%          plain_fsm:handle_system_msg(
-%%              From, Req, S, fun(S1) -> idle(S1) end);
+%%              Req, From, S, fun(S1) -> idle(S1) end);
 %%       {'EXIT', Parent, Reason} ->
 %%          plain_fsm:parent_EXIT(Reason, S);
 %%       ... %% your original code here
@@ -528,7 +528,7 @@ parent_EXIT(Reason, _State) ->
 %% idle(S) ->
 %%   receive
 %%      {system, From, Req} ->
-%%          plain_fsm:handle_system_msg(From, Req, S, fun(S1) ->
+%%          plain_fsm:handle_system_msg(Req, From, S, fun(S1) ->
 %%                                                           idle(S1)
 %%                                                    end);
 %%      ...


### PR DESCRIPTION
In https://github.com/uwiger/plain_fsm/blob/master/src/plain_fsm.erl#L531, the function is documented to be called as `plain_fsm:handle_system_msg(From, Req, S, ...)` -- but the function definition https://github.com/uwiger/plain_fsm/blob/master/src/plain_fsm.erl#L543 has the two first arguments the other way around `handle_system_msg(Req, From, ...)`
