### PR TITLE
fix compilation upstream

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,13 +6,10 @@
 {cover_enabled, true}.
 {clean_files, [".eunit", "ebin/*.beam","*~","*/*~"]}.
 
-{profiles,
- %% edown-related config (for generating github-friendly edoc)
- [
-  {deps,
-   [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.8"}}}]},
-  {edoc_opts, [{doclet, edown_doclet},
-               {top_level_readme,
-                {"./README.md",
-                 "http://github.com/uwiger/plain_fsm"}}]}
- ]}.
+{profiles, [{docs, [{deps, [{edown, "0.8.1"}]},
+                    {edoc_opts, [{doclet, edown_doclet},
+                                 {doc_path, []},
+                                 {top_level_readme,
+                                  {"./README.md","https://github.com/uwiger/plain_fsm"}}]}]}
+
+           ]}.


### PR DESCRIPTION
latest version doesn't compile with locks on second pass. Also this allows to get down only when running the command `rebar3 doc`