### PR TITLE
Handle annotations and locations better

### DIFF
--- a/src/plain_fsm.erl
+++ b/src/plain_fsm.erl
@@ -241,7 +241,7 @@
                sys = #sys{}}).
 
 
--define(line(Tup), element(2, Tup)).
+-define(anno(Tup), element(2, Tup)).
 
 %% ================ Internal functions ==================
 


### PR DESCRIPTION
This PR is one of several affecting repositories on Github. It
aims at fixing bad use of annotations (see erl_anno(3)). The
following remarks are common to all PR:s.

Typically the second element of abstract code tuples is assumed
to be an integer, which is no longer always true. For instance,
the parse transform implementing QLC tables (see qlc(3)) returns
code where some annotations are marked as `generated'. Such an
annotation is a list, not an integer (it used to be a negative
integer).

As of Erlang/OTP 24.0, the location can be a tuple {Line, Column},
which is another reason to handle annotations properly.