### PR TITLE
Avoid warnings in generated code for underscored variable names

### DIFF
--- a/src/plain_fsm_xform.erl
+++ b/src/plain_fsm_xform.erl
@@ -109,7 +109,7 @@ xform_plainfsm(Forms) ->
                                             erl_syntax:clause(
                                               [erl_syntax:match_expr(
                                                  erl_syntax:variable(
-                                                   '__FSM_State'),
+                                                   'FSM@@State__'),
                                                  Pat)],
                                               CGd,
                                               CBod),
@@ -223,7 +223,7 @@ extended_recv(Arg, Fname) ->
 get_parent_expr() ->
     A0 = erl_anno:new(0),
     {match,A0,
-     {var,A0,'__FSM_Parent'},
+     {var,A0,'FSM@@Parent__'},
      {call,A0,{remote,A0,
               {atom,A0,?PLAIN_FSM},
               {atom,A0,info}},
@@ -233,32 +233,32 @@ get_parent_expr() ->
 extend_recv(Clauses, Cont) ->
     [erl_syntax:clause(
        [erl_syntax:tuple([erl_syntax:atom('EXIT'),
-                          erl_syntax:variable('__FSM_Parent'),
-                          erl_syntax:variable('__FSM_Reason')])],
+                          erl_syntax:variable('FSM@@Parent__'),
+                          erl_syntax:variable('FSM@@Reason__')])],
        [],
        [erl_syntax:application(
           erl_syntax:atom(?PLAIN_FSM),
           erl_syntax:atom(parent_EXIT),
-          [erl_syntax:variable('__FSM_Reason'),
-           erl_syntax:variable('__FSM_State')])]),
+          [erl_syntax:variable('FSM@@Reason__'),
+           erl_syntax:variable('FSM@@State__')])]),
      erl_syntax:clause(
        [erl_syntax:tuple([erl_syntax:atom(system),
-                          erl_syntax:variable('__FSM_From'),
-                          erl_syntax:variable('__FSM_Req')])],
+                          erl_syntax:variable('FSM@@From__'),
+                          erl_syntax:variable('FSM@@Req__')])],
        [],
        [erl_syntax:application(
           erl_syntax:atom(?PLAIN_FSM),
           erl_syntax:atom(handle_system_msg),
-          [erl_syntax:variable('__FSM_Req'),
-           erl_syntax:variable('__FSM_From'),
-           erl_syntax:variable('__FSM_State'),
+          [erl_syntax:variable('FSM@@Req__'),
+           erl_syntax:variable('FSM@@From__'),
+           erl_syntax:variable('FSM@@State__'),
            erl_syntax:fun_expr(
             [erl_syntax:clause(
-               [erl_syntax:variable('__FSM_Sx')],
+               [erl_syntax:variable('FSM@@Sx__')],
                [],
                [erl_syntax:application(
                   Cont,
-                  [erl_syntax:variable('__FSM_Sx')])])])])
+                  [erl_syntax:variable('FSM@@Sx__')])])])])
        ]) | Clauses].
 
 


### PR DESCRIPTION
In Erlang 24, it is a warning to match a variable that
begins with an underscore.  Avoid this for generated code
with variables such as __FSM_State.

With the following program,
```erlang
-module(x).
-compile({parse_transform,plain_fsm_xform}).
-export([data_vsn/0, x/1]).

data_vsn() ->
    1.

x(State) ->
    plain_fsm:extended_receive(
      receive
          _X ->
              x(State)
      end).
```
I got the warning below. The problem with the warning is that it can be an error if one has `warnings_as_errors`.
```
1> c("x", [debug_info]).
x.erl:0: Warning: variable '__FSM_Parent' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
{ok,x}
```
The interesting idea to use a `$` in the generated variable name to avoid the warning was not mine, but thanks to @attah