### PR TITLE
Fix badmatch when data_vsn/0 not defined

### DIFF
--- a/src/plain_fsm_xform.erl
+++ b/src/plain_fsm_xform.erl
@@ -308,11 +308,11 @@ maybe_add_vsn_f(Forms) ->
                 [{eof,LastLocation}|RevFns] = lists:reverse(Fns),
                 Anno1 = erl_anno:new(incr_line(LastLocation, 1)),
                 Line2 = incr_line(LastLocation, 2),
-                Anno = erl_anno:new(LastLocation),
+                Anno2 = erl_anno:new(LastLocation),
                 lists:reverse(
                   [{eof,Line2},
-                   {function,Anno,data_vsn,0,
-                    [{clause,Anno,[],[],[{integer,Anno1,0}]}]}
+                   {function,Anno2,data_vsn,0,
+                    [{clause,Anno2,[],[],[{integer,Anno1,0}]}]}
                    | RevFns])
         end,
     Pre1 ++ Fns1.


### PR DESCRIPTION
The parse transformation would fail with a badmatch error when the optional data_vsn/0 function was not defined.

The error looked like this:

```
foo.erl:none: error in parse transform 'plain_fsm_xform': {{badmatch,136
1},
                                             [{plain_fsm_xform,
                                               maybe_add_vsn_f,1,
                                               [{file,
                                                 "src/plain_fsm_xform.erl"},
                                                {line,311}]},
                                              {plain_fsm_xform,
                                               parse_transform,2,
                                               [{file,
                                                 "src/plain_fsm_xform.erl"},
                                                {line,48}]},
                                              {compile,
                                               '-foldl_transform/3-anonymous-1-',
                                               3,
                                               [{file,"compile.erl"},
                                                {line,1171}]},
                                              {compile,foldl_transform,3,
                                               [{file,"compile.erl"},
                                                {line,1174}]},
                                              {compile,
                                               '-internal_comp/5-anonymous-0-',
                                               3,
                                               [{file,"compile.erl"},
                                                {line,404}]},
                                              {compile,fold_comp,4,
                                               [{file,"compile.erl"},
                                                {line,431}]},
                                              {compile,internal_comp,5,
                                               [{file,"compile.erl"},
                                                {line,415}]},
                                              {compile,
                                               '-do_compile/2-anonymous-0-',2,
                                               [{file,"compile.erl"},
                                                {line,207}]}]}

```